### PR TITLE
Trigge deaktivere av alle oppgaver om ettersending ved vedtak eller avslag fra Arena

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,7 +42,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/feature/DAG-742_vedtakOgAvslagFraArena'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,7 +42,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/feature/DAG-742_vedtakOgAvslagFraArena'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+* @navikt/teamdagpenger

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/Main.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/Main.kt
@@ -17,6 +17,7 @@ import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Notifikasjoner
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers.AvslagPåMinsteinntektRiver
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers.BeskjedRiver
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers.DokumentInnsendtRiver
+import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers.VedtakFraArenaRiver
 import no.nav.helse.rapids_rivers.RapidApplication
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerConfig
@@ -80,6 +81,7 @@ fun main() {
             BeskjedRiver(rapidsConnection, notifikasjoner)
             DokumentInnsendtRiver(rapidsConnection, ettersendinger, config[soknadsdialogens_url].toURL())
             AvslagPåMinsteinntektRiver(rapidsConnection, ettersendinger)
+            VedtakFraArenaRiver(rapidsConnection, ettersendinger)
         }.start()
 }
 

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/Main.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/Main.kt
@@ -14,7 +14,6 @@ import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ettersendinger
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.KubernetesScretsMottakerkilde
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.NotifikasjonBroadcaster
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Notifikasjoner
-import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers.AvslagPåMinsteinntektRiver
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers.BeskjedRiver
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers.DokumentInnsendtRiver
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers.VedtakFraArenaRiver
@@ -80,7 +79,6 @@ fun main() {
         .build { _, rapidsConnection ->
             BeskjedRiver(rapidsConnection, notifikasjoner)
             DokumentInnsendtRiver(rapidsConnection, ettersendinger, config[soknadsdialogens_url].toURL())
-            AvslagPåMinsteinntektRiver(rapidsConnection, ettersendinger)
             VedtakFraArenaRiver(rapidsConnection, ettersendinger)
         }.start()
 }

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/NotifikasjonRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/NotifikasjonRepository.kt
@@ -12,4 +12,5 @@ internal interface NotifikasjonRepository {
     fun lagre(done: Done): Boolean
 
     fun hentAktiveOppgaver(ident: Ident, søknadId: UUID): List<Oppgave>
+    fun hentAlleAktiveOppgaver(ident: Ident): List<Oppgave>
 }

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepository.kt
@@ -96,6 +96,14 @@ internal class PostgresNotifikasjonRepository(
         )
     }
 
+    override fun hentAlleAktiveOppgaver(ident: Ident): List<Oppgave> = sessionOf(dataSource).use { session ->
+        session.run(
+            alleOppgaverForKonkretBrukerQuery(ident).map {
+                it.toOppgave()
+            }.asList
+        )
+    }
+
     internal fun hentInaktiveOppgaver(ident: Ident, søknadId: UUID): List<Oppgave> = sessionOf(dataSource).use { session ->
         session.run(
             oppgaverForKonkretSøknadQuery(ident, søknadId, false).map {
@@ -113,6 +121,18 @@ internal class PostgresNotifikasjonRepository(
         mapOf(
             "ident" to ident.ident,
             "soknadId" to søknadId,
+            "aktiv" to aktiv
+        )
+    )
+
+    private fun alleOppgaverForKonkretBrukerQuery(ident: Ident, aktiv : Boolean = true) = queryOf( //language=PostgreSQL
+        """SELECT * 
+            FROM oppgave o 
+            JOIN nokkel n ON n.id = o.nokkel
+            WHERE n.ident = :ident AND aktiv = :aktiv
+            """.trimIndent(),
+        mapOf(
+            "ident" to ident.ident,
             "aktiv" to aktiv
         )
     )

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepository.kt
@@ -71,11 +71,16 @@ internal class PostgresNotifikasjonRepository(
         val tabell = done.eventtype.name.lowercase()
         return queryOf( //language=PostgreSQL
             """
-        UPDATE $tabell SET aktiv = false, deaktiveringstidspunkt = :deaktiveringstidspunkt WHERE nokkel = :nokkel
+        UPDATE $tabell SET 
+            aktiv = false, 
+            deaktiveringstidspunkt = :deaktiveringstidspunkt,
+            deaktiveringsgrunn = :deaktiveringsgrunn 
+            WHERE nokkel = :nokkel
         """.trimIndent(),
             mapOf(
                 "nokkel" to nøkkelPK,
-                "deaktiveringstidspunkt" to done.deaktiveringstidspunkt
+                "deaktiveringstidspunkt" to done.tidspunkt,
+                "deaktiveringsgrunn" to done.grunn.toString()
             )
         )
     }
@@ -148,6 +153,7 @@ internal class PostgresNotifikasjonRepository(
         link = URL(string("link")),
         aktiv = boolean("aktiv"),
         deaktiveringstidspunkt = localDateTimeOrNull("deaktiveringstidspunkt"),
+        deaktiveringsgrunn = stringOrNull("deaktiveringsgrunn")?.let { Done.Grunn.valueOf(it) },
         synligFramTil = localDateTime("synligFramTil")
     )
 

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/notifikasjoner/Done.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/notifikasjoner/Done.kt
@@ -17,13 +17,15 @@ internal data class Done(
     private val ident: Ident,
     override val eventId: UUID,
     private val deaktiveringstidspunkt: LocalDateTime,
+    private val grunn: Grunn,
     private val eventtype: Eventtype
 ) : NotifikasjonKommando(), NotifikasjonMelding<DoneInput> {
 
-    constructor(ident: Ident, eventId: UUID, eventtype: Eventtype) : this(
+    constructor(ident: Ident, eventId: UUID, grunn: Grunn, eventtype: Eventtype) : this(
         ident,
         eventId,
         LocalDateTime.now(),
+        grunn,
         eventtype
     )
 
@@ -38,14 +40,21 @@ internal data class Done(
     fun getSnapshot() = DoneSnapshot(this)
 
     internal data class DoneSnapshot(
-        val deaktiveringstidspunkt: LocalDateTime,
+        val tidspunkt: LocalDateTime,
+        val grunn: Grunn,
         val eventtype: Eventtype
     ) {
-        constructor(done: Done) : this(done.deaktiveringstidspunkt, done.eventtype)
+        constructor(done: Done) : this(done.deaktiveringstidspunkt, done.grunn, done.eventtype)
     }
 
     internal enum class Eventtype {
         BESKJED, OPPGAVE
+    }
+
+    internal enum class Grunn {
+        FERDIG,
+        VEDTAK_ELLER_AVSLAG,
+        UTLOPT
     }
 
 }

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/notifikasjoner/Oppgave.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/notifikasjoner/Oppgave.kt
@@ -25,6 +25,7 @@ internal data class Oppgave(
     private val link: URL,
     private val søknadId: UUID,
     private val deaktiveringstidspunkt: LocalDateTime?,
+    private val deaktiveringsgrunn: Done.Grunn?,
     private val synligFramTil : LocalDateTime,
     private val aktiv: Boolean = true
 ) : NotifikasjonKommando(), NotifikasjonMelding<OppgaveInput> {
@@ -46,6 +47,7 @@ internal data class Oppgave(
         false,
         link,
         søknadId,
+        null,
         null,
         synligFramTil
     )
@@ -78,6 +80,7 @@ internal data class Oppgave(
         val søknadId: UUID,
         val aktiv: Boolean,
         val deaktiveringstidspunkt: LocalDateTime?,
+        val deaktiveringsgrunn: Done.Grunn?,
         val synligFramTil: LocalDateTime
     ) {
         constructor(oppgave: Oppgave) : this(
@@ -91,6 +94,7 @@ internal data class Oppgave(
             oppgave.søknadId,
             oppgave.aktiv,
             oppgave.deaktiveringstidspunkt,
+            oppgave.deaktiveringsgrunn,
             oppgave.synligFramTil
         )
     }

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/Ettersendinger.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/Ettersendinger.kt
@@ -60,8 +60,22 @@ internal class Ettersendinger(
 
     private fun List<Oppgave>.erFlereEnnEn() = size > 1
 
-    fun markerAlleOppgaverSomUtført(ident: Ident) {
-        TODO("Not yet implemented")
+    fun deaktiverAlleOppgaver(deaktivering: Deaktivering) {
+        val aktiveOppgaver = notifikasjonRepository.hentAlleAktiveOppgaver(deaktivering.ident)
+        logger.info { "Fant ${aktiveOppgaver.size} aktive oppgaver" }
+
+        if (aktiveOppgaver.isEmpty()) {
+            logger.info { "Det finnes ingen aktive oppgaver for brukeren, dermed er det ikke noe å deaktivere." }
+            return
+        }
+
+        aktiveOppgaver.forEach { aktivOppgave ->
+            val eventId = aktivOppgave.getSnapshot().eventId
+            withLoggingContext("eventId" to eventId.toString()) {
+                notifikasjoner.send(deaktivering.somDoneEvent(eventId))
+                logger.info { "Oppgaven har blitt deaktivert." }
+            }
+        }
     }
 
 }
@@ -76,6 +90,20 @@ internal data class EttersendingUtført(
             eventId = eventId,
             ident = ident,
             deaktiveringstidspunkt = deaktiveringstidspunkt,
+            eventtype = Done.Eventtype.OPPGAVE
+        )
+    }
+}
+
+internal data class Deaktivering(
+    val ident: Ident,
+    val tidspunkt: LocalDateTime
+) {
+    fun somDoneEvent(eventId: UUID): Done {
+        return Done(
+            eventId = eventId,
+            ident = ident,
+            deaktiveringstidspunkt = tidspunkt,
             eventtype = Done.Eventtype.OPPGAVE
         )
     }

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/Ettersendinger.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/Ettersendinger.kt
@@ -90,6 +90,7 @@ internal data class EttersendingUtført(
             eventId = eventId,
             ident = ident,
             deaktiveringstidspunkt = deaktiveringstidspunkt,
+            grunn = Done.Grunn.FERDIG,
             eventtype = Done.Eventtype.OPPGAVE
         )
     }
@@ -97,13 +98,15 @@ internal data class EttersendingUtført(
 
 internal data class Deaktivering(
     val ident: Ident,
-    val tidspunkt: LocalDateTime
+    val tidspunkt: LocalDateTime,
+    val grunn : Done.Grunn
 ) {
     fun somDoneEvent(eventId: UUID): Done {
         return Done(
             eventId = eventId,
             ident = ident,
             deaktiveringstidspunkt = tidspunkt,
+            grunn = grunn,
             eventtype = Done.Eventtype.OPPGAVE
         )
     }

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/Ettersendinger.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/Ettersendinger.kt
@@ -60,6 +60,10 @@ internal class Ettersendinger(
 
     private fun List<Oppgave>.erFlereEnnEn() = size > 1
 
+    fun markerAlleOppgaverSomUtført(ident: Ident) {
+        TODO("Not yet implemented")
+    }
+
 }
 
 internal data class EttersendingUtført(

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiver.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiver.kt
@@ -1,0 +1,55 @@
+package no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers
+
+import mu.KotlinLogging
+import mu.withLoggingContext
+import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ettersendinger
+import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ident
+import no.nav.helse.rapids_rivers.*
+
+internal class VedtakFraArenaRiver(
+    rapidsConnection: RapidsConnection,
+    private val ettersendinger: Ettersendinger
+) : River.PacketListener {
+
+    init {
+        River(rapidsConnection).apply {
+            validate { it.demandValue("table", "SIAMO.VEDTAK") }
+            validate {
+                it.requireKey(
+                    "op_ts",
+                    "after.VEDTAK_ID",
+                    "after.SAK_ID",
+                    "after.FRA_DATO"
+                )
+            }
+            validate { it.requireAny("after.VEDTAKTYPEKODE", listOf("O", "G", "E")) }
+            validate { it.requireAny("after.UTFALLKODE", listOf("JA", "NEI")) }
+            validate { it.interestedIn("after", "tokens") }
+            validate { it.interestedIn("after.TIL_DATO") }
+            validate { it.interestedIn("tokens.FODSELSNR") }
+            validate { it.interestedIn("FODSELSNR") }
+        }.register(this)
+    }
+
+    private companion object {
+        val logger = KotlinLogging.logger { }
+    }
+
+    override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        val ident = Ident(packet.fødselsnummer())
+        val vedtakId = packet["after"]["VEDTAK_ID"].asText()
+        val sakId = packet["after"]["SAK_ID"].asText()
+
+        withLoggingContext(
+            "fagsakId" to sakId,
+            "vedtakId" to vedtakId
+        ) {
+            logger.info { "Mottok nytt vedtak" }
+
+            ettersendinger.markerAlleOppgaverSomUtført(ident)
+        }
+    }
+}
+
+internal fun JsonMessage.fødselsnummer(): String =
+    if (this["tokens"].isMissingOrNull()) this["FODSELSNR"].asText() else this["tokens"]["FODSELSNR"].asText()

--- a/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiver.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiver.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers
 
 import mu.KotlinLogging
 import mu.withLoggingContext
+import no.nav.dagpenger.behov.brukernotifikasjon.notifikasjoner.Done
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Deaktivering
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ettersendinger
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ident
@@ -52,7 +53,8 @@ internal class VedtakFraArenaRiver(
             sikkerLogger.info { "Mottok nytt vedtak for person ${ident.ident}: ${packet.toJson()}" }
             val deaktivering = Deaktivering(
                 ident,
-                opprettet
+                opprettet,
+                Done.Grunn.VEDTAK_ELLER_AVSLAG
             )
             ettersendinger.deaktiverAlleOppgaver(deaktivering)
         }

--- a/src/main/resources/db/migration/V7__LEGG_TIL_KOLONNE_FOR_DEAKTIVERINGSGRUNN.sql
+++ b/src/main/resources/db/migration/V7__LEGG_TIL_KOLONNE_FOR_DEAKTIVERINGSGRUNN.sql
@@ -1,0 +1,5 @@
+ALTER TABLE oppgave
+    ADD COLUMN
+        deaktiveringsgrunn VARCHAR(255) NULL;
+
+UPDATE oppgave SET deaktiveringsgrunn = 'FERDIG' WHERE aktiv = false;

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/OppgaveObjectMother.kt
@@ -26,6 +26,7 @@ internal object OppgaveObjectMother {
         link = link,
         søknadId = søknadId,
         deaktiveringstidspunkt = null,
+        deaktiveringsgrunn = null,
         synligFramTil = synligFramTil,
         aktiv = aktiv
     )

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepositoryTest.kt
@@ -135,7 +135,7 @@ class PostgresNotifikasjonRepositoryTest {
     }
 
     @Test
-    fun `Et done-event skal deaktivere et korresponderende aktivt oppgave-event`() {
+    fun `Et done-event skal deaktivere et korresponderende aktivt oppgave-event`() = withMigratedDb {
         with(PostgresNotifikasjonRepository(dataSource)) {
             val ident = Ident("98765432101")
             val eventId = UUID.randomUUID()

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepositoryTest.kt
@@ -78,7 +78,10 @@ class PostgresNotifikasjonRepositoryTest {
 
             val aktiveOppgaverTilknyttetSøknaden = hentAktiveOppgaver(ident, expectedSøknadId)
             assertEquals(1, aktiveOppgaverTilknyttetSøknaden.size)
-            assertEquals(expectedOppgave1.getSnapshot().eventId, aktiveOppgaverTilknyttetSøknaden[0].getSnapshot().eventId)
+            assertEquals(
+                expectedOppgave1.getSnapshot().eventId,
+                aktiveOppgaverTilknyttetSøknaden[0].getSnapshot().eventId
+            )
         }
     }
 
@@ -87,18 +90,19 @@ class PostgresNotifikasjonRepositoryTest {
         with(PostgresNotifikasjonRepository(dataSource)) {
             val ident = Ident("12345678901")
 
-            val expectedOppgave1 = giveMeOppgave(ident = ident, søknadId = UUID.randomUUID())
-            val expectedOppgave2 = giveMeOppgave(ident = ident, søknadId = UUID.randomUUID())
+            val expectedEventId1 = UUID.randomUUID()
+            val expectedEventId2 = UUID.randomUUID()
             val inaktivOppgave = giveMeOppgave(ident = ident, aktiv = false)
             val oppgaveTilAnnenBruker = giveMeOppgave(ident = Ident("45678901234"))
-            lagre(expectedOppgave1)
-            lagre(expectedOppgave2)
+            lagre(giveMeOppgave(ident = ident, søknadId = expectedEventId1))
+            lagre(giveMeOppgave(ident = ident, søknadId = expectedEventId2))
             lagre(inaktivOppgave)
             lagre(oppgaveTilAnnenBruker)
 
-            val aktiveOppgaverTilknyttetSøknaden = hentAlleAktiveOppgaver(ident)
-            assertEquals(2, aktiveOppgaverTilknyttetSøknaden.size)
-            assertTrue(aktiveOppgaverTilknyttetSøknaden.containsAll(listOf(expectedOppgave1, expectedOppgave2)))
+            val aktiveOppgaver = hentAlleAktiveOppgaver(ident)
+            assertEquals(2, aktiveOppgaver.size)
+            assertNotNull(aktiveOppgaver.find { it.getSnapshot().søknadId == expectedEventId1 })
+            assertNotNull(aktiveOppgaver.find { it.getSnapshot().søknadId == expectedEventId2 })
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/db/PostgresNotifikasjonRepositoryTest.kt
@@ -149,12 +149,15 @@ class PostgresNotifikasjonRepositoryTest {
             val oppgaver = hentAktiveOppgaver(ident, søknadId)
             assertEquals(1, oppgaver.size)
 
-            val doneEventForOppgave = Done(ident = ident, eventId = eventId, Done.Eventtype.OPPGAVE)
+            val grunn = Done.Grunn.FERDIG
+            val doneEventForOppgave = Done(ident, eventId, grunn, Done.Eventtype.OPPGAVE)
             lagre(doneEventForOppgave)
 
             val oppgaverEtterDeaktivering = hentInaktiveOppgaver(ident, søknadId)
             assertEquals(1, oppgaverEtterDeaktivering.size)
-            assertNotNull(oppgaverEtterDeaktivering[0].getSnapshot().deaktiveringstidspunkt)
+            val deaktivertOppgave = oppgaverEtterDeaktivering[0].getSnapshot()
+            assertNotNull(deaktivertOppgave.deaktiveringstidspunkt)
+            assertEquals(grunn, deaktivertOppgave.deaktiveringsgrunn)
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/EttersendingerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/EttersendingerTest.kt
@@ -100,4 +100,39 @@ class EttersendingerTest {
         verify(exactly = 0) { notifikasjoner.send(any<Done>()) }
     }
 
+    @Test
+    fun `Skal deaktivere alle oppgaver for en bestemt bruker`() {
+        val ident = Ident("56478965481")
+        val deaktivering = Deaktivering(ident, LocalDateTime.now())
+        val oppgave1 = giveMeOppgave(ident = ident, søknadId = UUID.randomUUID())
+        val oppgave2 = giveMeOppgave(ident = ident, søknadId = UUID.randomUUID())
+
+        val notifikasjoner = mockk<Notifikasjoner>(relaxed = true)
+        val notifikasjonRepo = mockk<NotifikasjonRepository>(relaxed = true)
+        every { notifikasjonRepo.hentAlleAktiveOppgaver(ident) } returns listOf(oppgave1, oppgave2)
+        val ettersendinger = Ettersendinger(notifikasjoner, notifikasjonRepo)
+
+        ettersendinger.deaktiverAlleOppgaver(deaktivering)
+
+        verify(exactly = 2) {
+            notifikasjoner.send(any<Done>())
+        }
+    }
+
+    @Test
+    fun `Skal ikke gjøre noe hvis bruker ikke har noen oppgaver`() {
+        val ident = Ident("56478965481")
+        val deaktivering = Deaktivering(ident, LocalDateTime.now())
+
+        val notifikasjoner = mockk<Notifikasjoner>(relaxed = true)
+        val notifikasjonRepo = mockk<NotifikasjonRepository>(relaxed = true)
+        val ettersendinger = Ettersendinger(notifikasjoner, notifikasjonRepo)
+
+        ettersendinger.deaktiverAlleOppgaver(deaktivering)
+
+        verify(exactly = 0) {
+            notifikasjoner.send(any<Done>())
+        }
+    }
+
 }

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/DokumentInnsendtRiverTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/DokumentInnsendtRiverTest.kt
@@ -48,8 +48,9 @@ internal class DokumentInnsendtRiverTest {
 
         val snapshotAvOpprettetOppgave = opprettetOppgave.captured.getSnapshot()
         assertContains(snapshotAvOpprettetOppgave.link.toString(), søknadId.toString())
-        val omTreUkerMinusEtMinutt = LocalDateTime.now().plusWeeks(3).minusMinutes(1)
-        val omTreUkerPlusEtMinutt = LocalDateTime.now().plusWeeks(3).plusMinutes(1)
+        val nå = LocalDateTime.now()
+        val omTreUkerMinusEtMinutt = nå.plusWeeks(3).minusMinutes(1)
+        val omTreUkerPlusEtMinutt = nå.plusWeeks(3).plusMinutes(1)
         assertTrue(snapshotAvOpprettetOppgave.synligFramTil.isAfter(omTreUkerMinusEtMinutt))
         assertTrue(snapshotAvOpprettetOppgave.synligFramTil.isBefore(omTreUkerPlusEtMinutt))
     }

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiverTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiverTest.kt
@@ -2,12 +2,14 @@ package no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers
 
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Deaktivering
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ettersendinger
 import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ident
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 
 class VedtakFraArenaRiverTest {
 
@@ -24,38 +26,40 @@ class VedtakFraArenaRiverTest {
     }
 
     @Test
-    fun `Skal deaktivere alle oppgave som brukeren har, for versjon 1 av formatet fra Arena`() {
-        val ident = Ident("12345678901")
+    fun `Skal deaktivere alle oppgaver som brukeren har, for versjon 1 av formatet fra Arena`() {
+        val expectedIdent = Ident("12345678901")
+        val expectedTidspunkt = LocalDateTime.now()
         Vedtaktypekode.values().forEach { kode ->
-            rapid.sendTestMessage(vedtakJsonV1(ident, kode))
+            rapid.sendTestMessage(vedtakJsonV1(expectedIdent, kode, expectedTidspunkt))
         }
 
-        val capturedIdents = mutableListOf<Ident>()
-
+        val deaktiveringer = mutableListOf<Deaktivering>()
         verify {
-            ettersendinger.markerAlleOppgaverSomUtført(capture(capturedIdents))
+            ettersendinger.deaktiverAlleOppgaver(capture(deaktiveringer))
         }
 
-        capturedIdents.forEach{ capturedIdent ->
-            assertEquals(ident, capturedIdent)
+        deaktiveringer.forEach { deaktivering ->
+            assertEquals(expectedIdent, deaktivering.ident)
+            assertEquals(expectedTidspunkt, deaktivering.tidspunkt)
         }
     }
 
     @Test
-    fun `Skal deaktivere alle oppgave som brukeren har, for versjon 2 av formatet fra Arena`() {
-        val ident = Ident("12345678901")
+    fun `Skal deaktivere alle oppgaver som brukeren har, for versjon 2 av formatet fra Arena`() {
+        val expectedIdent = Ident("12345678901")
+        val expectedTidspunkt = LocalDateTime.now()
         Vedtaktypekode.values().forEach { vedtaktypekode ->
-            rapid.sendTestMessage(vedtakJsonV2(ident, vedtaktypekode))
+            rapid.sendTestMessage(vedtakJsonV2(expectedIdent, vedtaktypekode, expectedTidspunkt))
         }
 
-        val capturedIdents = mutableListOf<Ident>()
-
+        val deaktiveringer = mutableListOf<Deaktivering>()
         verify(exactly = 3) {
-            ettersendinger.markerAlleOppgaverSomUtført(capture(capturedIdents))
+            ettersendinger.deaktiverAlleOppgaver(capture(deaktiveringer))
         }
 
-        capturedIdents.forEach { capturedIdent ->
-            assertEquals(ident, capturedIdent)
+        deaktiveringer.forEach { deaktivering ->
+            assertEquals(expectedIdent, deaktivering.ident)
+            assertEquals(expectedTidspunkt, deaktivering.tidspunkt)
         }
     }
 
@@ -64,7 +68,11 @@ class VedtakFraArenaRiverTest {
     }
 
     //language=JSON
-    private fun vedtakJsonV1(ident: Ident, vedtaktypekode: Vedtaktypekode) = """{
+    private fun vedtakJsonV1(
+        ident: Ident,
+        vedtaktypekode: Vedtaktypekode,
+        opprettet: LocalDateTime = LocalDateTime.now().minusHours(1)
+    ) = """{
       "table": "SIAMO.VEDTAK",
       "op_type": "I",
       "op_ts": "2020-04-07 14:31:08.840468",
@@ -83,12 +91,17 @@ class VedtakFraArenaRiverTest {
         "PERSON_ID": 4124685,
         "FRA_DATO": "2018-03-05 00:00:00",
         "TIL_DATO": null
-      }
+      },
+      "@opprettet": "$opprettet"
     }
     """.trimIndent()
 
     //language=JSON
-    private fun vedtakJsonV2(ident: Ident, vedtaktypekode: Vedtaktypekode) = """{
+    private fun vedtakJsonV2(
+        ident: Ident,
+        vedtaktypekode: Vedtaktypekode,
+        opprettet: LocalDateTime = LocalDateTime.now().minusHours(2)
+    ) = """{
         "table": "SIAMO.VEDTAK",
         "op_type": "I",
         "op_ts": "2021-11-12 08:31:33.092337",
@@ -105,7 +118,8 @@ class VedtakFraArenaRiverTest {
             "PERSON_ID": 4124685,
             "FRA_DATO": "2018-03-05 00:00:00",
             "TIL_DATO": null
-        }
+        },
+        "@opprettet": "$opprettet"
     }
 """.trimIndent()
 

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiverTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiverTest.kt
@@ -63,8 +63,10 @@ class VedtakFraArenaRiverTest {
         }
     }
 
-    private enum class Vedtaktypekode {
-        E, G, O
+    private enum class Vedtaktypekode(val kode : String) {
+        ENDRING("E"),
+        GJENNOPPTAK("G"),
+        ORDINÆR("O")
     }
 
     //language=JSON
@@ -85,7 +87,7 @@ class VedtakFraArenaRiverTest {
         "VEDTAK_ID": 29501880,
         "SAK_ID": 123,
         "VEDTAKSTATUSKODE": "IVERK",
-        "VEDTAKTYPEKODE": "${vedtaktypekode.name}",
+        "VEDTAKTYPEKODE": "${vedtaktypekode.kode}",
         "UTFALLKODE": "JA",
         "RETTIGHETKODE": "DAGO",
         "PERSON_ID": 4124685,
@@ -112,7 +114,7 @@ class VedtakFraArenaRiverTest {
             "VEDTAK_ID": 29501880,
             "SAK_ID": 123,
             "VEDTAKSTATUSKODE": "IVERK",
-            "VEDTAKTYPEKODE": "${vedtaktypekode.name}",
+            "VEDTAKTYPEKODE": "${vedtaktypekode.kode}",
             "UTFALLKODE": "JA",
             "RETTIGHETKODE": "DAGO",
             "PERSON_ID": 4124685,

--- a/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiverTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/brukernotifikasjon/tjenester/rivers/VedtakFraArenaRiverTest.kt
@@ -1,0 +1,112 @@
+package no.nav.dagpenger.behov.brukernotifikasjon.tjenester.rivers
+
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ettersendinger
+import no.nav.dagpenger.behov.brukernotifikasjon.tjenester.Ident
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class VedtakFraArenaRiverTest {
+
+    private val ettersendinger = mockk<Ettersendinger>(relaxed = true)
+    private val rapid by lazy {
+        TestRapid().apply {
+            VedtakFraArenaRiver(this, ettersendinger)
+        }
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        rapid.reset()
+    }
+
+    @Test
+    fun `Skal deaktivere alle oppgave som brukeren har, for versjon 1 av formatet fra Arena`() {
+        val ident = Ident("12345678901")
+        Vedtaktypekode.values().forEach { kode ->
+            rapid.sendTestMessage(vedtakJsonV1(ident, kode))
+        }
+
+        val capturedIdents = mutableListOf<Ident>()
+
+        verify {
+            ettersendinger.markerAlleOppgaverSomUtført(capture(capturedIdents))
+        }
+
+        capturedIdents.forEach{ capturedIdent ->
+            assertEquals(ident, capturedIdent)
+        }
+    }
+
+    @Test
+    fun `Skal deaktivere alle oppgave som brukeren har, for versjon 2 av formatet fra Arena`() {
+        val ident = Ident("12345678901")
+        Vedtaktypekode.values().forEach { vedtaktypekode ->
+            rapid.sendTestMessage(vedtakJsonV2(ident, vedtaktypekode))
+        }
+
+        val capturedIdents = mutableListOf<Ident>()
+
+        verify(exactly = 3) {
+            ettersendinger.markerAlleOppgaverSomUtført(capture(capturedIdents))
+        }
+
+        capturedIdents.forEach { capturedIdent ->
+            assertEquals(ident, capturedIdent)
+        }
+    }
+
+    private enum class Vedtaktypekode {
+        E, G, O
+    }
+
+    //language=JSON
+    private fun vedtakJsonV1(ident: Ident, vedtaktypekode: Vedtaktypekode) = """{
+      "table": "SIAMO.VEDTAK",
+      "op_type": "I",
+      "op_ts": "2020-04-07 14:31:08.840468",
+      "current_ts": "2020-04-07T14:53:03.656001",
+      "pos": "00000000000000013022",
+      "tokens": {
+        "FODSELSNR": "${ident.ident}"
+      },
+      "after": {
+        "VEDTAK_ID": 29501880,
+        "SAK_ID": 123,
+        "VEDTAKSTATUSKODE": "IVERK",
+        "VEDTAKTYPEKODE": "${vedtaktypekode.name}",
+        "UTFALLKODE": "JA",
+        "RETTIGHETKODE": "DAGO",
+        "PERSON_ID": 4124685,
+        "FRA_DATO": "2018-03-05 00:00:00",
+        "TIL_DATO": null
+      }
+    }
+    """.trimIndent()
+
+    //language=JSON
+    private fun vedtakJsonV2(ident: Ident, vedtaktypekode: Vedtaktypekode) = """{
+        "table": "SIAMO.VEDTAK",
+        "op_type": "I",
+        "op_ts": "2021-11-12 08:31:33.092337",
+        "current_ts": "2021-11-12 08:57:55.082000",
+        "pos": "00000000000000010892",
+        "FODSELSNR": "${ident.ident}",
+        "after": {
+            "VEDTAK_ID": 29501880,
+            "SAK_ID": 123,
+            "VEDTAKSTATUSKODE": "IVERK",
+            "VEDTAKTYPEKODE": "${vedtaktypekode.name}",
+            "UTFALLKODE": "JA",
+            "RETTIGHETKODE": "DAGO",
+            "PERSON_ID": 4124685,
+            "FRA_DATO": "2018-03-05 00:00:00",
+            "TIL_DATO": null
+        }
+    }
+""".trimIndent()
+
+}


### PR DESCRIPTION
Lytter på eventer fra Arena på samme måte som i `dp-innsyn`, men lytter i tillegg på meldinger med `vedtaktypekode` satt til `Endring`.

DAG-742